### PR TITLE
Tree Crown Detection using DeepForest

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -22,6 +22,8 @@ parts:
       sections:
       - file: forest/modelling/forest-modelling-structure
         title: Structure
+      - file: forest/modelling/forest-modelling-treecrown_deepforest
+        title: Tree crown (DeepForest)
   - file: polar/polar-overview
     title: Polar
     sections:

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,8 @@ dependencies:
   - intake-xarray
   - bottleneck
   - pooch
-  - pytorch==1.8.0
-  - torchvision==0.9.0
+  - pytorch==1.9.0
+  - torchvision==0.10.0
   - geoviews
   - iris==3.0.1
   - urllib3


### PR DESCRIPTION
A PR for contributing a Tree Crown detection using the [`deepforest`](https://deepforest.readthedocs.io) python package demonstrator notebook to the Environmental AI book. This notebook:

- Use `intake` and `intake_zenodo_fetcher` to fetch a very-high resolution imagery from Zenodo.
- Visualisation of the image and labels from the fetched source.
- Load and use a pretrained model from the `deepforest` package.
- Compare full-image and tile-wise predictions.