### PR TITLE
Remove transfer step in guidelines and templates

### DIFF
--- a/book/publishing/guidelines/guidelines-authors.md
+++ b/book/publishing/guidelines/guidelines-authors.md
@@ -69,7 +69,8 @@ Each reviewer is guided by a checklist which facilitate to evaluate the notebook
 Reviewers are encouraged to make detailed comments directly to the notebook repo.
 To facilitate the conversation, EiC opens a `review` PR in the notebook repository where authors and reviewers carry out a detailed discussion through ReviewNB, a third-party plugin in GitHub for displaying and commenting Jupyter Notebooks (see further details [here](../about/notebooks-technologies.md)).
 Authors should implement relevant changes in the notebook repository hosted in their personal GitHub account, and submit changes to the `review` branch created by EiC (for example, see [here](https://github.com/eds-book-gallery/67a1e320-7c47-4ea9-8df8-e868326bc90b/pull/6) a PR submitted from the author of the IceNet Python API notebook).
-EiC will merge changes into the `review` PR and ask reviewers to re-evaluate the notebook.
+EiC will merge changes into the `review` PR.
+The editor should ask reviewers to re-evaluate the notebook.
 
 Once reviewers recommend the notebook for publication, the editor pings EiC to start the post-print stage.
 

--- a/book/publishing/guidelines/guidelines-authors.md
+++ b/book/publishing/guidelines/guidelines-authors.md
@@ -46,8 +46,7 @@ Some general guidelines are:
 When the minimal working version of the notebook is ready, authors should tag EiC in the PR with the latest Binder badge.
 EiC will check how reproducible is the notebook and its feasibility for the reviewing stage. 
 
-After EiC's approval of the draft version of the notebook, authors transfer the notebook repository to the [eds-book-gallery](https://github.com/eds-book-gallery) organisation. 
-Please see [here](https://docs.github.com/en/enterprise-server@3.4/repositories/creating-and-managing-repositories/transferring-a-repository) how to transfer repositories according to the official GitHub documentation. 
+After EiC's approval of the draft version of the notebook, the EiC will fork the notebook repository to the [eds-book-gallery](https://github.com/eds-book-gallery) organisation. 
 
 EiC will assist you to prepare the notebook repository for the review process.
 
@@ -68,7 +67,9 @@ Please contact the editor directly or in the REVIEW issue thread to inform possi
 Authors should address reviewers suggestions according to their relevance.
 Each reviewer is guided by a checklist which facilitate to evaluate the notebook.
 Reviewers are encouraged to make detailed comments directly to the notebook repo.
-To facilitate this, EiC opens a PR in the notebook repository where authors and reviewers carry out a detailed discussion through ReviewNB, a third-party plugin in GitHub for displaying and commenting Jupyter Notebooks (see further details [here](../about/notebooks-technologies.md)).
+To facilitate the conversation, EiC opens a `review` PR in the notebook repository where authors and reviewers carry out a detailed discussion through ReviewNB, a third-party plugin in GitHub for displaying and commenting Jupyter Notebooks (see further details [here](../about/notebooks-technologies.md)).
+Authors should implement relevant changes in the notebook repository hosted in their personal GitHub account, and submit changes to the `review` branch created by EiC (for example, see [here](https://github.com/eds-book-gallery/67a1e320-7c47-4ea9-8df8-e868326bc90b/pull/6) a PR submitted from the author of the IceNet Python API notebook).
+EiC will merge changes into the `review` PR and ask reviewers to re-evaluate the notebook.
 
 Once reviewers recommend the notebook for publication, the editor pings EiC to start the post-print stage.
 

--- a/book/publishing/guidelines/guidelines-editors.md
+++ b/book/publishing/guidelines/guidelines-editors.md
@@ -41,7 +41,10 @@ Reviewers should check off items of the checklist one-by-one, until done.
 In the meantime, reviewers can engage the authors freely in a conversation aimed at improving the notebook.
 The editor lurks on this conversation and comes in if needed for questions (or CoC issues).
 Comments in the REVIEW issue should be kept general with more lengthy suggestions or requests posted directly in the PR opened by EiC in the notebook repository. 
-
+The authors should implement changes in their personal repository and not in the forked repository. 
+The authors should open a PR to the forked repository to update the notebook version for review.
+EiC merges the PR in the `review` branch.
+The editor should confirm the reviewers are satisfied with the changes and ask them to re-evaluate the notebook.
 When reviewers are satisfied with the improvements, the editor asks to confirm their recommendation to accept the submission.
 Then the editor pings EiC to inform the notebook is ready to the post-print stage.
 

--- a/book/publishing/guidelines/guidelines-eic.md
+++ b/book/publishing/guidelines/guidelines-eic.md
@@ -20,9 +20,9 @@ In this step, we suggest providing feedback to the notebook idea.
 EiC validate how reproducible is the notebook and its feasibility for the reviewing stage. 
 This process is aided by the Binder badge in a PR in the corresponding author's notebook repository.
 
-After validating a minimal working version, EiC transfer the notebook repository to the [Environmental Data Science book organisation](https://github.com/eds-book-gallery). 
+After validating a minimal working version, EiC fork the notebook repository to the [Environmental Data Science book organisation](https://github.com/eds-book-gallery). 
 
-The notebook in the transferred repository should generate the same outputs as the initial repository hosted in the GitHub account of the corresponding author. 
+The forked notebook should generate the same outputs as the initial repository hosted in the GitHub account of the corresponding author. 
 
 Before moving to PRE-REVIEW, EiC open a new issue `Preparation` in the notebook repository and complete the checklist below: 
 
@@ -44,9 +44,11 @@ Once reviewers agreed on the revision, EiC open a REVIEW issue.
 ## Review
 The [REVIEW issue](https://github.com/alan-turing-institute/environmental-ds-book/issues/new?assignees=&labels=review&projects=&template=review-template.md&title=%5BREVIEW%5D) aims to be a space where editor will moderate timings and conversation between authors and reviewers.
 
-To facilitate the discussion, EiC creates a new branch `review` to add reviewers info (name, affiliation, GitHub handle) in the contribution section of the notebook. 
+To facilitate the discussion, EiC creates a new branch `review` with a custom message at the first markdown cell indicating "Authors and Reviewers. This is the notebook version for review. We will remove this markdown cell after the peer-review." 
 Then EiC commit and push changes to create a PR in the notebook repository. 
 The PR will trigger ReviewNB, a third-party plugin in GitHub for displaying and commenting Jupyter Notebooks (see further details [here](../about/notebooks-technologies.md)).
+EiC should reminder the authors to implement changes in their personal repository and not in the forked repository. The authors should open a PR to the forked repository to update the notebook version for review.
+EiC merges the PR in the `review` branch and suggest to the editor to ask the reviewers to re-evaluate the notebook.
 
 Once reviewers recommend the notebook for publication, EiC will be notified by the editor to start the post-print stage.
 

--- a/book/publishing/guidelines/guidelines-reviewers.md
+++ b/book/publishing/guidelines/guidelines-reviewers.md
@@ -42,5 +42,7 @@ Additional comments are welcome on the same issue or directly to the notebook re
 If reviewers do the latter, they will find a PR in the notebook repository where authors and reviewers carry out the discussion through ReviewNB, a third-party plugin in GitHub for displaying and commenting Jupyter Notebooks (see further details [here](../about/notebooks-technologies.md)).
 Reviewers can open issues in the notebook repo too and link the URL of the notebook REVIEW issue thread.
 This facilitates centralizing comments.
+All changes implemented by authors will be available in the `review` PR. 
+The editor will ask reviewers to re-evaluate the notebook after the authors' changes.
 
 Authors should respond within 2 weeks with their changes to the notebook in response to reviewers comments.


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes #243 by removing the transfer step in the guides and templates.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Remove the transfer step in all guidelines, except the guide for community.
* Remove the image and transfer step in the templates for [Python](https://github.com/eds-book-gallery/template_python), [R](https://github.com/eds-book-gallery/template_r) and [Julia](https://github.com/eds-book-gallery/template_julia).

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] Everything looks ok?

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->